### PR TITLE
Harden CI checkout with persist-credentials: false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
             -   id: checkout
                 name: Checkout
                 uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+                with:
+                    persist-credentials: false
 
             -   id: setup_php
                 name: Set up PHP version ${{ matrix.php }}


### PR DESCRIPTION
Addresses magicsunday/.github#1 (zizmor `artipacked`).

Sets `persist-credentials: false` on the `actions/checkout` step in `ci.yml`. This workflow has no downstream step that needs the job token (no `git push`, no private-VCS `composer install`), so dropping the persisted credential is safe.

Verified: YAML parses, `actionlint` adds no new finding, only `ci.yml` changes.