### PR TITLE
Support webtrees-theme packages alongside webtrees-module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,9 @@ jobs:
               if: ${{ always() && steps.install.conclusion == 'success' }}
               run: |
                   composer ci:cgl -- --dry-run
+
+            - id: unit
+              name: PHPUnit
+              if: ${{ always() && steps.install.conclusion == 'success' }}
+              run: |
+                  composer ci:test:php:unit

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Simple setup with minimal configuration required in your composer.json file.
 ## 🌟 Why Use This Plugin?
 When developing or using modules for webtrees, managing the installation process can be cumbersome. This plugin solves that problem by:
 
-- Automatically detecting and installing modules with the `webtrees-module` type
-- Placing modules in the correct `modules_v4` directory structure
+- Automatically detecting and installing packages of type `webtrees-module` and `webtrees-theme`
+- Placing modules and themes in the correct `modules_v4` directory structure
 - Supporting both direct installation and installation via a separate composer.json
 - Eliminating the need for manual file copying or symlink creation
 
@@ -78,6 +78,21 @@ When creating a webtrees module, set the package type to `webtrees-module` in yo
 #### Pro Tip
 The module name in the composer.json file will determine the directory name in the `modules_v4` directory.
 
+#### Themes
+Themes are installed exactly like modules. Since a webtrees theme is a module as well, set the package type to `webtrees-theme` and it will be placed in the same `modules_v4` directory:
+
+```json
+{
+    "name": "your-vendor-name/your-theme-name",
+    "description": "Your theme description",
+    "type": "webtrees-theme",
+    "require": {
+        "php": "8.3 - 8.5",
+        "magicsunday/webtrees-module-installer-plugin": "^2.0"
+    }
+}
+```
+
 ### Installing from GitHub
 If your module is not listed on Packagist, you can install it directly from GitHub:
 
@@ -104,15 +119,16 @@ composer ci:test:php:lint     # PHP linting
 composer ci:test:php:phpstan  # Static analysis
 composer ci:test:php:rector   # Code quality checks
 composer ci:test:php:cgl      # Coding guidelines
+composer ci:test:php:unit     # Unit tests (PHPUnit)
 ```
 
 ## 🔍 How It Works
 The plugin works by:
 
 1. Registering a custom installer with Composer's installation manager
-2. Subscribing to package-level events (`PRE_PACKAGE_*` / `POST_PACKAGE_*`) to queue `webtrees-module` operations
+2. Subscribing to package-level events (`PRE_PACKAGE_*` / `POST_PACKAGE_*`) to queue `webtrees-module` and `webtrees-theme` operations
 3. Determining the correct installation path in the `modules_v4` directory, whether `fisharebest/webtrees` is installed as a dependency or as the root package
-4. Re-installing all `webtrees-module` packages when `fisharebest/webtrees` itself is updated, so the modules survive the core upgrade
+4. Re-installing all `webtrees-module` and `webtrees-theme` packages when `fisharebest/webtrees` itself is updated, so the modules and themes survive the core upgrade
 
 The main components are:
 - `ModuleInstallerPlugin`: Implements Composer's `PluginInterface` and wires up the event listeners

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
             "MagicSunday\\Webtrees\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "MagicSunday\\Webtrees\\Test\\": "tests/"
+        }
+    },
     "extra": {
         "class": "MagicSunday\\Webtrees\\Composer\\ModuleInstallerPlugin",
         "branch-alias": {
@@ -47,6 +52,7 @@
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpunit/phpunit": "^12.0",
         "rector/rector": "^2.0"
     },
     "scripts": {
@@ -65,6 +71,9 @@
         "ci:test:php:phpstan": [
             "phpstan analyze --configuration phpstan.neon --memory-limit=-1"
         ],
+        "ci:test:php:unit": [
+            "phpunit --configuration phpunit.xml"
+        ],
         "ci:test:php:phpstan:baseline": [
             "phpstan analyze --configuration phpstan.neon --memory-limit=-1 --generate-baseline phpstan-baseline.neon --allow-empty-baseline"
         ],
@@ -75,7 +84,8 @@
             "@ci:test:php:lint",
             "@ci:test:php:phpstan",
             "@ci:test:php:rector",
-            "@ci:test:php:cgl"
+            "@ci:test:php:cgl",
+            "@ci:test:php:unit"
         ]
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./.build/vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./.build/vendor/autoload.php"
+         cacheDirectory="./.build/cache/.phpunit.cache"
+         colors="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         failOnNotice="true"
+         failOnDeprecation="true"
+         beStrictAboutOutputDuringTests="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Composer/ModuleInstaller.php
+++ b/src/Composer/ModuleInstaller.php
@@ -27,9 +27,10 @@ use function React\Promise\resolve;
 use function rtrim;
 
 /**
- * ModuleInstaller is responsible for handling the installation of packages with the type `webtrees-module`.
- * It integrates with Composer's library installation process and ensures modules are correctly placed
- * into the appropriate path within the `fisharebest/webtrees` directory structure if installed.
+ * ModuleInstaller is responsible for handling the installation of packages of type `webtrees-module`
+ * and `webtrees-theme`. It integrates with Composer's library installation process and ensures modules
+ * and themes are correctly placed into the appropriate path within the `fisharebest/webtrees` directory
+ * structure if installed.
  *
  * @author  Rico Sonntag <mail@ricosonntag.de>
  * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
@@ -48,6 +49,12 @@ class ModuleInstaller extends LibraryInstaller
     public const string PACKAGE_TYPE = 'webtrees-module';
 
     /**
+     * The theme package type handled by this installer. Themes are webtrees modules too and
+     * therefore install into the same `modules_v4` directory.
+     */
+    public const string PACKAGE_TYPE_THEME = 'webtrees-theme';
+
+    /**
      * The directory used to install the module into.
      */
     private const string MODULES_DIR = 'modules_v4' . DIRECTORY_SEPARATOR;
@@ -56,6 +63,23 @@ class ModuleInstaller extends LibraryInstaller
      * Whether to skip the installation process of a package.
      */
     private bool $skipInstall = false;
+
+    /**
+     * Determines whether this installer handles packages of the given type.
+     *
+     * Both `webtrees-module` and `webtrees-theme` packages are handled, as webtrees themes
+     * are modules as well and live in the same `modules_v4` directory.
+     *
+     * @param string $packageType The composer package type to check
+     *
+     * @return bool True if the package type is handled by this installer
+     */
+    #[Override]
+    public function supports(string $packageType): bool
+    {
+        return ($packageType === self::PACKAGE_TYPE)
+            || ($packageType === self::PACKAGE_TYPE_THEME);
+    }
 
     /**
      * Executes the given operation unless skipInstall is set, in which case resolves immediately with null.

--- a/src/Composer/ModuleInstallerPlugin.php
+++ b/src/Composer/ModuleInstallerPlugin.php
@@ -24,9 +24,9 @@ use Composer\Plugin\PluginInterface;
 use function sprintf;
 
 /**
- * A Composer plugin to handle the installation, update, and uninstallation of webtrees modules.
+ * A Composer plugin to handle the installation, update, and uninstallation of webtrees modules and themes.
  * This plugin listens to various Composer events and manages the deployment of packages of type
- * "webtrees-module" into a specific target directory within the webtrees application.
+ * "webtrees-module" and "webtrees-theme" into a specific target directory within the webtrees application.
  *
  * @author  Rico Sonntag <mail@ricosonntag.de>
  * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
@@ -118,13 +118,13 @@ class ModuleInstallerPlugin implements PluginInterface
         $operation = $event->getOperation();
         $package   = $this->getPackageFromOperation($operation);
 
-        if ($package->getType() === ModuleInstaller::PACKAGE_TYPE) {
+        if ($this->installer->supports($package->getType())) {
             $this->installer->skipInstallation(true);
 
             $this->pendingPackages[$package->getName()] = $operation;
         }
 
-        // If root packages gets updated, reinstall all webtrees-module packages
+        // If the root package gets updated, reinstall all packages handled by this installer
         if (
             ($operation instanceof UpdateOperation)
             && ($package->getName() === ModuleInstaller::ROOT_PACKAGE_NAME)
@@ -135,7 +135,7 @@ class ModuleInstallerPlugin implements PluginInterface
                 ->getCanonicalPackages();
 
             foreach ($canonicalPackages as $canonicalPackage) {
-                if ($canonicalPackage->getType() !== ModuleInstaller::PACKAGE_TYPE) {
+                if (!$this->installer->supports($canonicalPackage->getType())) {
                     continue;
                 }
 

--- a/tests/Composer/CreatesModuleInstaller.php
+++ b/tests/Composer/CreatesModuleInstaller.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-module-installer-plugin.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Test\Composer;
+
+use Composer\Composer;
+use Composer\Config;
+use Composer\Downloader\DownloadManager;
+use Composer\IO\IOInterface;
+use MagicSunday\Webtrees\Composer\ModuleInstaller;
+
+/**
+ * Builds a real module installer whose framework collaborators are stubbed, so the installer's
+ * own routing logic runs unmodified while the surrounding Composer machinery stays inert.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-module-installer-plugin/
+ */
+trait CreatesModuleInstaller
+{
+    /**
+     * Creates a module installer backed by a minimally configured, stubbed Composer instance.
+     *
+     * @return ModuleInstaller
+     */
+    private function createModuleInstaller(): ModuleInstaller
+    {
+        $config = new Config(false);
+        $config->merge([
+            'config' => [
+                'vendor-dir' => 'vendor',
+                'bin-dir'    => 'vendor/bin',
+            ],
+        ]);
+
+        $composer = $this->createStub(Composer::class);
+        $composer->method('getConfig')->willReturn($config);
+        $composer->method('getDownloadManager')->willReturn($this->createStub(DownloadManager::class));
+
+        return new ModuleInstaller(
+            $this->createStub(IOInterface::class),
+            $composer,
+            ModuleInstaller::PACKAGE_TYPE
+        );
+    }
+}

--- a/tests/Composer/ModuleInstallerPluginTest.php
+++ b/tests/Composer/ModuleInstallerPluginTest.php
@@ -1,0 +1,223 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-module-installer-plugin.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Test\Composer;
+
+use Composer\Composer;
+use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\DependencyResolver\Operation\UninstallOperation;
+use Composer\DependencyResolver\Operation\UpdateOperation;
+use Composer\Installer\PackageEvent;
+use Composer\Package\Package;
+use Composer\Repository\InstalledRepositoryInterface;
+use Composer\Repository\RepositoryManager;
+use MagicSunday\Webtrees\Composer\ModuleInstaller;
+use MagicSunday\Webtrees\Composer\ModuleInstallerPlugin;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Tests the package-event handling of the installer plugin. The plugin is wired to a real
+ * ModuleInstaller so the type routing it delegates to is exercised for real, not re-stubbed.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-module-installer-plugin/
+ */
+#[CoversClass(ModuleInstallerPlugin::class)]
+#[UsesClass(ModuleInstaller::class)]
+class ModuleInstallerPluginTest extends TestCase
+{
+    use CreatesModuleInstaller;
+
+    /**
+     * Creates a package with the given name and composer type.
+     *
+     * @param string $name The composer package name
+     * @param string $type The composer package type
+     *
+     * @return Package
+     */
+    private function createPackage(string $name, string $type): Package
+    {
+        $package = new Package($name, '1.0.0.0', '1.0.0');
+        $package->setType($type);
+
+        return $package;
+    }
+
+    /**
+     * Builds a pre-package event wrapping an install operation for the given package.
+     *
+     * @param Package $package The package the operation installs
+     *
+     * @return PackageEvent
+     */
+    private function createInstallEvent(Package $package): PackageEvent
+    {
+        $event = $this->createStub(PackageEvent::class);
+        $event->method('getOperation')->willReturn(new InstallOperation($package));
+
+        return $event;
+    }
+
+    /**
+     * Builds a pre-package event wrapping an update operation for the given package.
+     *
+     * @param Package $package The package the operation updates
+     *
+     * @return PackageEvent
+     */
+    private function createUpdateEvent(Package $package): PackageEvent
+    {
+        $event = $this->createStub(PackageEvent::class);
+        $event->method('getOperation')->willReturn(new UpdateOperation($package, $package));
+
+        return $event;
+    }
+
+    /**
+     * Creates a Composer stub whose local repository exposes the given canonical packages.
+     *
+     * @param array<Package> $packages The canonical packages the local repository should return
+     *
+     * @return Composer
+     */
+    private function createComposerWithCanonicalPackages(array $packages): Composer
+    {
+        $localRepository = $this->createStub(InstalledRepositoryInterface::class);
+        $localRepository->method('getCanonicalPackages')->willReturn($packages);
+
+        $repositoryManager = $this->createStub(RepositoryManager::class);
+        $repositoryManager->method('getLocalRepository')->willReturn($localRepository);
+
+        $composer = $this->createStub(Composer::class);
+        $composer->method('getRepositoryManager')->willReturn($repositoryManager);
+
+        return $composer;
+    }
+
+    /**
+     * Creates a plugin wired to a real installer and, optionally, a stubbed Composer instance.
+     *
+     * @param Composer|null $composer The Composer instance to inject, or null when unused
+     *
+     * @return array{0: ModuleInstallerPlugin, 1: ReflectionClass<ModuleInstallerPlugin>}
+     */
+    private function createPlugin(?Composer $composer = null): array
+    {
+        $plugin     = new ModuleInstallerPlugin();
+        $reflection = new ReflectionClass($plugin);
+
+        $reflection->getProperty('installer')->setValue($plugin, $this->createModuleInstaller());
+
+        if ($composer !== null) {
+            $reflection->getProperty('composer')->setValue($plugin, $composer);
+        }
+
+        return [$plugin, $reflection];
+    }
+
+    /**
+     * Reads the plugin's pending package operations keyed by package name.
+     *
+     * @param ModuleInstallerPlugin                $plugin     The plugin to inspect
+     * @param ReflectionClass<ModuleInstallerPlugin> $reflection A reflection handle for the plugin
+     *
+     * @return array<string, InstallOperation|UpdateOperation|UninstallOperation>
+     */
+    private function readPendingPackages(ModuleInstallerPlugin $plugin, ReflectionClass $reflection): array
+    {
+        /** @var array<string, InstallOperation|UpdateOperation|UninstallOperation> $pendingPackages */
+        $pendingPackages = $reflection->getProperty('pendingPackages')->getValue($plugin);
+
+        return $pendingPackages;
+    }
+
+    /**
+     * A webtrees-theme package must be queued for processing just like a module.
+     *
+     * @return void
+     */
+    #[Test]
+    public function queuesThemePackageForProcessing(): void
+    {
+        [$plugin, $reflection] = $this->createPlugin();
+
+        $plugin->onPrePackageEvent($this->createInstallEvent($this->createPackage('vendor/example-theme', 'webtrees-theme')));
+
+        self::assertArrayHasKey('vendor/example-theme', $this->readPendingPackages($plugin, $reflection));
+    }
+
+    /**
+     * A regular webtrees-module package must keep being queued for processing.
+     *
+     * @return void
+     */
+    #[Test]
+    public function queuesModulePackageForProcessing(): void
+    {
+        [$plugin, $reflection] = $this->createPlugin();
+
+        $plugin->onPrePackageEvent($this->createInstallEvent($this->createPackage('vendor/example-module', 'webtrees-module')));
+
+        self::assertArrayHasKey('vendor/example-module', $this->readPendingPackages($plugin, $reflection));
+    }
+
+    /**
+     * An unrelated package type must not be queued for processing.
+     *
+     * @return void
+     */
+    #[Test]
+    public function ignoresUnrelatedPackage(): void
+    {
+        [$plugin, $reflection] = $this->createPlugin();
+
+        $plugin->onPrePackageEvent($this->createInstallEvent($this->createPackage('vendor/example-library', 'library')));
+
+        self::assertSame([], $this->readPendingPackages($plugin, $reflection));
+    }
+
+    /**
+     * When the webtrees core package is updated, all handled packages must be re-queued so they
+     * survive the upgrade — including webtrees-theme packages, while unrelated packages are skipped.
+     *
+     * @return void
+     */
+    #[Test]
+    public function reinstallsHandledPackagesWhenRootPackageUpdates(): void
+    {
+        $canonicalPackages = [
+            $this->createPackage('vendor/canonical-theme', 'webtrees-theme'),
+            $this->createPackage('vendor/canonical-module', 'webtrees-module'),
+            $this->createPackage('vendor/canonical-library', 'library'),
+        ];
+
+        $composer = $this->createComposerWithCanonicalPackages($canonicalPackages);
+
+        [$plugin, $reflection] = $this->createPlugin($composer);
+
+        $rootPackage = $this->createPackage(ModuleInstaller::ROOT_PACKAGE_NAME, 'library');
+
+        $plugin->onPrePackageEvent($this->createUpdateEvent($rootPackage));
+
+        $pendingPackages = $this->readPendingPackages($plugin, $reflection);
+
+        self::assertCount(2, $pendingPackages);
+        self::assertArrayHasKey('vendor/canonical-theme', $pendingPackages);
+        self::assertArrayHasKey('vendor/canonical-module', $pendingPackages);
+        self::assertArrayNotHasKey('vendor/canonical-library', $pendingPackages);
+    }
+}

--- a/tests/Composer/ModuleInstallerTest.php
+++ b/tests/Composer/ModuleInstallerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-module-installer-plugin.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\Test\Composer;
+
+use MagicSunday\Webtrees\Composer\ModuleInstaller;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the package-type routing of the module installer.
+ *
+ * @author  Rico Sonntag <mail@ricosonntag.de>
+ * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
+ * @link    https://github.com/magicsunday/webtrees-module-installer-plugin/
+ */
+#[CoversClass(ModuleInstaller::class)]
+class ModuleInstallerTest extends TestCase
+{
+    use CreatesModuleInstaller;
+
+    /**
+     * The installer must keep handling the classic webtrees-module package type.
+     *
+     * @return void
+     */
+    #[Test]
+    public function supportsModulePackageType(): void
+    {
+        self::assertTrue($this->createModuleInstaller()->supports('webtrees-module'));
+    }
+
+    /**
+     * The installer must also handle the webtrees-theme package type so themes
+     * land in the modules_v4 directory just like ordinary modules.
+     *
+     * @return void
+     */
+    #[Test]
+    public function supportsThemePackageType(): void
+    {
+        self::assertTrue($this->createModuleInstaller()->supports('webtrees-theme'));
+    }
+
+    /**
+     * Unrelated package types must not be claimed by the installer.
+     *
+     * @return void
+     */
+    #[Test]
+    public function doesNotSupportUnrelatedPackageType(): void
+    {
+        self::assertFalse($this->createModuleInstaller()->supports('library'));
+    }
+}


### PR DESCRIPTION
## Summary
Webtrees themes are modules as well and live in the same `modules_v4/` directory. The installer now claims both the `webtrees-module` **and** the `webtrees-theme` composer package type, so a package declaring `"type": "webtrees-theme"` is installed into `modules_v4/` exactly like a module — matching how the companion `webtrees-module-updater` already treats both types.

## Changes
- `ModuleInstaller`: add `PACKAGE_TYPE_THEME` constant and override `supports()` to accept both types.
- `ModuleInstallerPlugin`: the pre-package event listeners now delegate the type decision to `$this->installer->supports(...)` instead of comparing against the module constant directly. This keeps the set of handled types in one place and routes themes through the same install queue and the post-core-upgrade reinstall as modules.
- README / class docblocks updated to mention themes.

## Tests
Adds a PHPUnit harness (`phpunit.xml`, `autoload-dev`, `ci:test:php:unit` script + CI step) and covers:
- `supports()` per type (`webtrees-module` → true, `webtrees-theme` → true, unrelated → false),
- queueing of module and theme packages on install, ignoring unrelated packages,
- re-queueing of all handled packages (module **and** theme) when `fisharebest/webtrees` itself is updated.

The plugin tests drive a real `ModuleInstaller` (only framework collaborators stubbed), so removing the theme branch from `supports()` turns the theme tests red.

`composer ci:test` (phplint + phpstan max + rector + php-cs-fixer + phpunit) is green on PHP 8.3–8.5.