### PR TITLE
Adopt the shared label sync

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,28 @@
+name: Labels
+
+# Apply the canonical magicsunday label set to this repository. The manifest
+# lives in magicsunday/.github; the sync is non-destructive, so labels specific
+# to this repository are preserved.
+on:
+    push:
+        branches: [main]
+        paths: ['.github/workflows/labels.yml']
+    schedule:
+        - cron: '15 4 * * 1'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+# Serialise runs so an overlapping schedule/dispatch/push cannot drive two
+# concurrent label mutations; do not cancel an in-flight sync mid-write.
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
+
+jobs:
+    sync:
+        uses: magicsunday/.github/.github/workflows/label-sync.yml@main
+        permissions:
+            contents: read
+            issues: write


### PR DESCRIPTION
Calls the reusable `label-sync.yml` from `magicsunday/.github`, so this repository's labels follow the canonical manifest.

- Triggers: weekly schedule (Mon 04:15 UTC), manual `workflow_dispatch`, and a `push` trigger scoped to this file only.
- `issues: write` is declared on the calling job because a reusable workflow's `GITHUB_TOKEN` is capped by the caller's permission ceiling.
- A concurrency guard (no cancel-in-progress) serialises overlapping schedule/dispatch/push runs so two label mutations never race.
- The sync runs with skip-delete, so labels specific to this repository are preserved.