### PR TITLE
Point the commit-subject rule at the shared gate

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,30 @@
+name: Commit lint
+
+# `edited` and the concurrency group are a package, not two independent choices.
+# The gate checks the pull-request title because this repository squash-merges,
+# and the default activity types do not include title edits — without `edited` a
+# title broken after a green run is never re-judged, and a title fixed after a red
+# one has nothing to re-run. But `edited` also makes several runs fire against the
+# same head commit, and branch protection keeps whichever finishes last: a green
+# run started before a title was broken can overwrite the red one that followed.
+# Cancelling in progress removes that race, and is safe because this gate mutates
+# nothing — only the newest title is meant to be judged.
+#
+# The calling job deliberately declares no `permissions:` block of its own: a
+# job-level block would replace the top-level one rather than merge with it, so
+# leaving it off is what makes the top-level grant below the one in effect.
+on:
+    pull_request:
+        types: [opened, reopened, synchronize, edited]
+
+permissions:
+    contents: read
+    pull-requests: read
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    commit-convention:
+        uses: magicsunday/.github/.github/workflows/commit-convention.yml@main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# webtrees-module-installer-plugin — agent notes
+
+This file collects contributor conventions for the
+`magicsunday/webtrees-module-installer-plugin` repository.
+
+## Git flow
+
+- Commit subjects — and the pull-request title — are governed by the shared `commit-convention` gate; the normative rule and its full rationale live in `magicsunday/.github/.github/workflows/commit-convention.yml@main`, which self-tests a decision table before applying it. In short: a `GH-`-prefixed subject must match `^GH-\d+: [A-Z]`, every other subject `^[A-Z]` — a capitalised English imperative — and conventional-commit prefixes (`feat:`, `Fix:`, …) as well as path-like starts (`src/…: …`) are rejected whatever their case. It runs on every pull request via `.github/workflows/commit-lint.yml`, advisory until `commit-convention / Commit convention` is a required context in branch protection.
+- Branches for an issue are named exactly `GH-<N>`; the `GH-<N>: ` prefix marks work that belongs to that issue, so a drive-by fix on the branch keeps its own unprefixed subject.
+- The pull-request body closes the issue with `Closes #<N>` — the `GH-<N>: ` subject prefix is not a GitHub link and closes nothing.
+- Never add a `Co-Authored-By:` trailer or any other AI attribution.


### PR DESCRIPTION
Wires the shared `commit-convention` gate into this repo via
`.github/workflows/commit-lint.yml` (byte-identical to the canonical file,
calling `magicsunday/.github/.github/workflows/commit-convention.yml@main`).

Documents the rule in `AGENTS.md` under a `## Git flow` section: a pointer to
the self-tested shared gate plus the local branch (`GH-<N>`), `Closes #<N>`
and no-AI-attribution conventions. No essay is duplicated in-repo.

The gate runs advisory on every PR until `commit-convention / Commit convention`
is made a required context in branch protection.
