### PR TITLE
GH-17: Add the AI issue labeler thin caller

### DIFF
--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -1,0 +1,31 @@
+name: Issue labels
+
+# Thin caller for the reusable AI issue labeler
+# (magicsunday/.github's ai-issue-labeler.yml). See that workflow's own
+# header comment for the full contract (label-set enum constraint,
+# needs-triage fallback, residual-risk acceptance).
+#
+# `uses: magicsunday/.github/.github/workflows/ai-issue-labeler.yml@main`
+# (the fully-qualified form) - a caller in a DIFFERENT repository than the
+# one that owns the reusable workflow, per that workflow's own documented
+# CALLER REQUIREMENTS block.
+#
+# REQUIRES the `ANTHROPIC_API_KEY` repository secret to be set on THIS repo
+# - this account has no org-wide secret inheritance (see
+# ai-issue-labeler.yml's own header comment for what happens, and its own
+# fail-loudly contract, when the secret is missing or invalid). That
+# failure is harmless here: it never blocks issue creation itself, since
+# `issues: write` is the only permission this caller grants.
+on:
+    issues:
+        types: [opened]
+
+permissions: {}
+
+jobs:
+    label:
+        uses: magicsunday/.github/.github/workflows/ai-issue-labeler.yml@main
+        permissions:
+            issues: write
+        secrets:
+            anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
This adds a thin caller for `magicsunday/.github`'s reusable `ai-issue-labeler.yml` workflow.

It is part of the rollout described in `magicsunday/.github#60` step 4.

The caller file is byte-identical to the one already piloted end-to-end (verified working, including a real cross-repo test) in `magicsunday/.github` itself and in `magicsunday/coding-standard`.

This repo already has the `ANTHROPIC_API_KEY` repository secret provisioned and a `needs-triage` label, so no further prerequisite work is needed before adding the caller workflow.

Closes #160.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated labeling for newly opened GitHub issues.
  * The workflow uses AI-assisted classification and applies labels automatically when configured with the required repository secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->