### PR TITLE
GH-19: Collapse the isset guard into a null-coalescing assignment

### DIFF
--- a/src/Composer/ModuleInstallerPlugin.php
+++ b/src/Composer/ModuleInstallerPlugin.php
@@ -139,9 +139,7 @@ class ModuleInstallerPlugin implements PluginInterface
                     continue;
                 }
 
-                if (!isset($this->pendingPackages[$canonicalPackage->getName()])) {
-                    $this->pendingPackages[$canonicalPackage->getName()] = new InstallOperation($canonicalPackage);
-                }
+                $this->pendingPackages[$canonicalPackage->getName()] ??= new InstallOperation($canonicalPackage);
             }
         }
     }


### PR DESCRIPTION
The `build (8.3)`, `build (8.4)` and `build (8.5)` required checks currently fail on `main` for every pull request, because Rector's `IfToNullCoalescingAssignRector` flags `ModuleInstallerPlugin.php` in a dry-run.

This applies Rector's own suggested transformation: an `if (!isset($x)) { $x = ...; }` guard collapses into `$x ??= ...;`. Behavior-preserving — an existing key with a null value is treated as "not set" by both `isset()` and `??=`, so the semantics match exactly.

Closes #19.
